### PR TITLE
Fix #1004: Wrong binary path in distro

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: tart
 
 before:
@@ -20,7 +22,8 @@ builds:
       path: '.build/{{- if eq .Arch "arm64" }}arm64{{- else }}x86_64{{ end }}-apple-macosx/release/tart'
 
 universal_binaries:
-  - replace: true
+  - name_template: tart.app/Contents/MacOS/tart
+    replace: true
     hooks:
       post: gon gon.hcl
 

--- a/gon.hcl
+++ b/gon.hcl
@@ -1,4 +1,4 @@
-source = [ "dist/tart_darwin_all/tart" ]
+source = [ "dist/tart_darwin_all/tart.app/Contents/MacOS/tart" ]
 bundle_id = "com.github.cirruslabs.tart"
 
 apple_id {


### PR DESCRIPTION
Also added `version` due goreleaser output.

```
$ goreleaser release --skip=publish --snapshot --clean

only configurations files on  version: 2  are supported, yours is  version: 0 , please update your configuration
```