### PR TITLE
fix(control-socket): use .path instead of .path() for stale socket cleanup

### DIFF
--- a/Sources/tart/ControlSocket.swift
+++ b/Sources/tart/ControlSocket.swift
@@ -19,7 +19,7 @@ class ControlSocket {
   func run() async throws {
     // Remove control socket file from previous "tart run" invocations,
     // if any, otherwise we may get the "address already in use" error
-    try? FileManager.default.removeItem(atPath: controlSocketURL.path())
+    try? FileManager.default.removeItem(atPath: controlSocketURL.path)
 
     // Change the current working directory to a VM's base directory
     // to work around Unix domain socket 104 byte limitation [1]

--- a/Tests/TartTests/ControlSocketURLTests.swift
+++ b/Tests/TartTests/ControlSocketURLTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import tart
+
+final class ControlSocketURLTests: XCTestCase {
+  func testControlSocketURLResolvesToAbsolutePath() throws {
+    let baseURL = URL(fileURLWithPath: "/Users/test/.tart/vms/myvm/")
+    let vmDir = VMDirectory(baseURL: baseURL)
+
+    // The .path property resolves relative URLs to absolute paths,
+    // which is required for stale socket cleanup in ControlSocket.run()
+    // since it happens before the working directory is changed.
+    XCTAssertEqual(
+      vmDir.controlSocketURL.path,
+      "/Users/test/.tart/vms/myvm/control.sock"
+    )
+  }
+
+  func testControlSocketURLRelativePathIsJustFilename() throws {
+    let baseURL = URL(fileURLWithPath: "/Users/test/.tart/vms/myvm/")
+    let vmDir = VMDirectory(baseURL: baseURL)
+
+    // The .relativePath is used for socket binding after cwd is changed
+    XCTAssertEqual(
+      vmDir.controlSocketURL.relativePath,
+      "control.sock"
+    )
+  }
+}


### PR DESCRIPTION
### Fix

 Change .path() → .path so removeItem receives the absolute path and can actually find and delete the stale socket.

 ### Testing

 - Confirmed the bug reproduces on macOS Sequoia 15.7.3 with Tart 2.32.0 using both Ubuntu and Rocky 9 VMs
 - Verified the fix resolves the issue: built patched Tart, reproduced the stop/start cycle, and tart exec works correctly after restart
 - Added unit tests verifying controlSocketURL resolves correctly for both the absolute cleanup path and the relative binding path

 ### Manual Verification

 Tested on macOS Sequoia 15.7.3 with a Rocky Linux 9 aarch64 VM (ghcr.io/cirruslabs/rocky:latest).

 Test A — Reproduce the bug with stock Tart 2.32.0:

 ```bash
# Remove any leftover socket for a clean starting state
rm -f ~/.tart/vms/rocky9/control.sock

# Start VM and exec -- works fine on first run
tart run rocky9 --no-graphics &
tart exec rocky9 uname -a   # succeeds

# Stop and restart
tart stop rocky9
ls ~/.tart/vms/rocky9/control.sock   # stale socket present
tart run rocky9 --no-graphics &

# Second exec after stop/start -- hangs, times out after 15s (exit 124)
timeout 15 tart exec rocky9 uname -a   # FAILS

tart stop rocky9
 ```

 Test B — Verify the fix with patched Tart:

 ```bash
# Change this to your own repo path
PATCHED=~/repos/tart/.build/arm64-apple-macosx/debug/tart

# Remove any leftover socket for a clean starting state
rm -f ~/.tart/vms/rocky9/control.sock

# Start VM with patched binary and exec -- works fine on first run
$PATCHED run rocky9 --no-graphics &
tart exec rocky9 uname -a   # succeeds

# Stop and restart with patched binary
tart stop rocky9
ls ~/.tart/vms/rocky9/control.sock   # stale socket present
$PATCHED run rocky9 --no-graphics &

# Second exec after stop/start -- patched binary cleans up stale socket
timeout 15 tart exec rocky9 uname -a   # succeeds

tart stop rocky9
 ```

 Fixes: https://github.com/cirruslabs/tart/issues/1220