### PR TITLE
Fix busy loop in `tart exec -i` after piped stdin reaches EOF

### DIFF
--- a/Sources/tart/Commands/Exec.swift
+++ b/Sources/tart/Commands/Exec.swift
@@ -129,6 +129,11 @@ struct Exec: AsyncParsableCommand {
               let data = handle.availableData
 
               if data.isEmpty {
+                // EOF: unregister the handler, otherwise the fd stays permanently
+                // "readable" and Foundation re-invokes us in a tight loop, burning
+                // 100% of a core for the rest of the command's lifetime
+                handle.readabilityHandler = nil
+
                 continuation.finish()
               } else {
                 continuation.yield(data)


### PR DESCRIPTION
Fixes #1280.

When stdin is a pipe or terminal, `Exec.execute` installs an `NSFileHandle.readabilityHandler` that is never unregistered. Once the pipe's write end closes, the fd stays permanently "readable", so Foundation's fd-monitoring dispatch source re-invokes the handler in a tight loop — each pass an `fstat` + zero-byte `read` + a no-op `finish()` on the already-finished continuation — burning 100% of one host core for the rest of the command's lifetime. Details, repro, and a `sample` trace of the hot loop are in #1280.

This is the pipe-branch sibling of #1100/#1106, which fixed the regular-file redirection case.

The fix is the standard remedy for this Foundation behavior: set `readabilityHandler = nil` on EOF before finishing the stream.

### Verification

On an M4 host (macOS 26.5.2) against a running VM, `printf 'ping\n' | tart exec -i <vm> bash -c 'IFS= read -r X; echo got $X; sleep 12'`:

| binary | CPU time after 10 s wall |
|---|---|
| tart 2.32.1 (stock) | 9.26 s (~100% of a core) |
| this branch | 0.06 s |

stdin is still delivered to the guest, output and exit code unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
