### PR TITLE
Document tart exec usage and examples

### DIFF
--- a/Sources/tart/Commands/Exec.swift
+++ b/Sources/tart/Commands/Exec.swift
@@ -9,9 +9,30 @@ struct ExecCustomExitCodeError: Error {
 
 struct Exec: AsyncParsableCommand {
   static var configuration = CommandConfiguration(abstract: "Execute a command in a running VM", discussion: """
-  Requires Tart Guest Agent running in a guest VM.
+  Runs a command inside a running VM without SSH or guest networking.
 
-  Note that all non-vanilla Cirrus Labs VM images already have the Tart Guest Agent installed.
+  Requires macOS 14 or newer and Tart Guest Agent running inside the guest VM.
+  All non-vanilla Cirrus Labs VM images already include Tart Guest Agent.
+
+  Commands run directly as the guest user running Tart Guest Agent. Use a shell
+  explicitly for shell features such as pipes, redirection, or environment
+  variable expansion. Tart exits with the guest command's exit code.
+
+  Examples:
+    Run a command:
+      tart exec tahoe-base /usr/bin/uname -a
+
+    Run a shell command:
+      tart exec tahoe-base /bin/sh -c 'pwd; printenv HOME'
+
+    Open an interactive shell:
+      tart exec -i -t tahoe-base /bin/zsh
+
+    Run a local script inside the guest VM:
+      tart exec -i tahoe-base /bin/sh < script.sh
+
+  See https://github.com/openai/tart-guest-agent for guest agent installation
+  and execution privileges.
   """)
 
   @Flag(name: [.customShort("i")], help: "Attach host's standard input to a remote command")


### PR DESCRIPTION
## Summary
- Expand `tart exec --help` with the macOS and guest-agent prerequisites and a link to the guest-agent documentation.
- Explain network-free execution, guest-user privileges, direct command versus shell execution, and guest exit-code propagation.
- Add copy-pasteable examples for running a command, running a shell command, opening an interactive shell, and redirecting a local script into the guest.

## Why
The `exec` help previously provided only a short overview and did not explain common usage or where to find guest-agent documentation.

## Validation
- `swift build --build-system swiftbuild --product tart --scratch-path /Users/fkorotkov/code/tart/.build` in a clean worktree: passed.
- Freshly built `tart exec --help`: verified that all four examples and the guest-agent documentation link render correctly.
- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --build-system swiftbuild --scratch-path /Users/fkorotkov/code/tart/.build`: passed; 56 tests, zero failures, four Docker-dependent registry tests skipped because Docker is not installed.
- `git diff --cached --check`: passed.
- Independent review agent: no actionable findings.