### PR TITLE
Build Tart on macOS 26 with Xcode 27

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   build_cached:
     name: Build tart (cached)
-    runs-on: macos-26
+    runs-on: xcode-27
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
@@ -29,7 +29,7 @@ jobs:
 
   build_no_cache:
     name: Build tart (no cache)
-    runs-on: macos-26
+    runs-on: xcode-27
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   test:
     name: Test
-    runs-on: macos-26
+    runs-on: xcode-27
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   release:
     if: github.event_name == 'push' && github.repository == 'openai/tart'
     name: Release
-    runs-on: macos-26
+    runs-on: xcode-27
     environment: publish
     timeout-minutes: 90
     permissions:
@@ -85,7 +85,7 @@ jobs:
   snapshot:
     if: github.event_name == 'workflow_dispatch'
     name: Release (Dry Run)
-    runs-on: macos-26
+    runs-on: xcode-27
     timeout-minutes: 90
     permissions:
       contents: read


### PR DESCRIPTION
So that we can take advantage of the new provisioning options (VZMacGuestProvisioningOptions) for macOS 27.