### PR TITLE
Support suspending and resuming Linux VMs

### DIFF
--- a/Sources/tart/Commands/Clone.swift
+++ b/Sources/tart/Commands/Clone.swift
@@ -66,9 +66,18 @@ struct Clone: AsyncParsableCommand {
       let lock = try FileLock(lockURL: Config().tartHomeDir)
       try lock.lock()
 
+      let sourceState = try sourceVM.state()
+      let sourceConfig = try VMConfig(fromURL: sourceVM.configURL)
+
       let generateMAC = try localStorage.hasVMsWithMACAddress(macAddress: sourceVM.macAddress())
-        && sourceVM.state() != .Suspended
+        && sourceState != .Suspended
       try sourceVM.clone(to: tmpVMDir, generateMAC: generateMAC)
+
+      if sourceState != .Suspended,
+         let linux = sourceConfig.platform as? Linux,
+         linux.machineIdentifier == nil {
+        try tmpVMDir.initializeLinuxMachineIdentifier()
+      }
 
       try localStorage.move(newName, from: tmpVMDir)
 

--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -271,7 +271,9 @@ struct Run: AsyncParsableCommand {
   var rootDiskOpts: String = ""
 
   #if arch(arm64)
-    @Flag(help: ArgumentHelp("Disables audio and entropy devices and switches to only Mac-specific input devices.", discussion: "Useful for running a VM that can be suspended via \"tart suspend\"."))
+    @Flag(
+      help: ArgumentHelp("Disables or replaces devices that do not support VM suspension, such as audio, entropy and some input devices.",
+                         discussion: "Useful for running a VM that can be suspended via \"tart suspend\"."))
   #endif
   var suspendable: Bool = false
 
@@ -359,7 +361,11 @@ struct Run: AsyncParsableCommand {
     if suspendable {
       let config = try VMConfig.init(fromURL: vmDir.configURL)
       if !(config.platform is PlatformSuspendable) {
-        throw ValidationError("You can only suspend macOS VMs")
+        throw ValidationError("This platform is not suspendable")
+      }
+
+      if let linux = config.platform as? Linux, linux.machineIdentifier == nil {
+        throw ValidationError("Linux VMs without a machine identifier cannot be suspended or resumed")
       }
 
       if noTrackpad {

--- a/Sources/tart/Platform/Linux.swift
+++ b/Sources/tart/Platform/Linux.swift
@@ -1,7 +1,42 @@
 import Virtualization
 
 @available(macOS 13, *)
-struct Linux: Platform {
+struct Linux: PlatformSuspendable {
+
+  var machineIdentifier: VZGenericMachineIdentifier?
+
+  init(machineIdentifier: VZGenericMachineIdentifier = VZGenericMachineIdentifier()) {
+    self.machineIdentifier = machineIdentifier
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    guard let encodedMachineIdentifier = try container.decodeIfPresent(
+      String.self, forKey: .machineIdentifier
+    ) else {
+      self.machineIdentifier = nil
+      return
+    }
+    guard let data = Data.init(base64Encoded: encodedMachineIdentifier) else {
+      throw DecodingError.dataCorruptedError(forKey: .machineIdentifier,
+                                             in: container,
+                                             debugDescription: "failed to initialize Data using the provided value")
+    }
+    guard let machineIdentifier = VZGenericMachineIdentifier.init(dataRepresentation: data) else {
+      throw DecodingError.dataCorruptedError(forKey: .machineIdentifier,
+                                             in: container,
+                                             debugDescription: "failed to initialize VZGenericMachineIdentifier using the provided value")
+    }
+    self.machineIdentifier = machineIdentifier
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encodeIfPresent(machineIdentifier?.dataRepresentation.base64EncodedString(), forKey: .machineIdentifier)
+  }
+
   func os() -> OS {
     .linux
   }
@@ -16,6 +51,11 @@ struct Linux: Platform {
 
   func platform(nvramURL: URL, needsNestedVirtualization: Bool) throws -> VZPlatformConfiguration {
     let config = VZGenericPlatformConfiguration()
+
+    if let machineIdentifier {
+      config.machineIdentifier = machineIdentifier
+    }
+
     if #available(macOS 15, *) {
       config.isNestedVirtualizationEnabled = needsNestedVirtualization
     }
@@ -46,5 +86,15 @@ struct Linux: Platform {
   func pointingDevicesSimplified() -> [VZPointingDeviceConfiguration] {
     // Linux doesn't support trackpad, so just return the regular pointing devices
     return pointingDevices()
+  }
+
+  func pointingDevicesSuspendable() -> [VZPointingDeviceConfiguration] {
+    // VZUSBScreenCoordinatePointingDeviceConfiguration passes save/restore
+    // validation, but causes restoring a Linux VM to fail with "invalid argument".
+    []
+  }
+
+  func keyboardsSuspendable() -> [VZKeyboardConfiguration] {
+    keyboards()
   }
 }

--- a/Sources/tart/VMConfig.swift
+++ b/Sources/tart/VMConfig.swift
@@ -30,6 +30,9 @@ enum CodingKeys: String, CodingKey {
   // macOS-specific keys
   case ecid
   case hardwareModel
+
+  // Linux-specific keys
+  case machineIdentifier
 }
 
 struct VMDisplayConfig: Codable, Equatable {

--- a/Sources/tart/VMDirectory.swift
+++ b/Sources/tart/VMDirectory.swift
@@ -142,6 +142,23 @@ struct VMDirectory: Prunable {
     try vmConfig.save(toURL: configURL)
   }
 
+  func initializeLinuxMachineIdentifier() throws {
+    var vmConfig = try VMConfig(fromURL: configURL)
+    guard var vmLinux = vmConfig.platform as? Linux else {
+      throw RuntimeError.VMConfigurationError("cannot initialize a Linux machine identifier on a non-Linux VM")
+    }
+    guard vmLinux.machineIdentifier == nil else {
+      throw RuntimeError.VMConfigurationError(
+        "cannot initialize a Linux machine identifier when one already exists"
+      )
+    }
+
+    vmLinux.machineIdentifier = VZGenericMachineIdentifier()
+    vmConfig.platform = vmLinux
+
+    try vmConfig.save(toURL: configURL)
+  }
+
   func resizeDisk(_ sizeGB: UInt16, format: DiskImageFormat = .raw) throws {
     let diskExists = FileManager.default.fileExists(atPath: diskURL.path)
 

--- a/Tests/TartTests/VMConfigTests.swift
+++ b/Tests/TartTests/VMConfigTests.swift
@@ -1,6 +1,9 @@
 import XCTest
 @testable import tart
 
+import Foundation
+import Virtualization
+
 final class VMConfigTests: XCTestCase {
   func testVMDisplayConfig() throws {
     // Defaults units (points)
@@ -14,5 +17,54 @@ final class VMConfigTests: XCTestCase {
     // Explicit units (pixels)
     vmDisplayConfig = VMDisplayConfig.init(argument: "1234x5678px")
     XCTAssertEqual(VMDisplayConfig(width: 1234, height: 5678, unit: .pixel), vmDisplayConfig)
+  }
+
+  func testLinuxMachineIdentifierSerialization() throws {
+    let originalIdentifier = VZGenericMachineIdentifier()
+    let originalConfig = VMConfig(
+      platform: Linux(machineIdentifier: originalIdentifier), cpuCountMin: 2, memorySizeMin: 1024 * 1024 * 1024
+    )
+    let encodedConfigData = try originalConfig.toJSON()
+
+    let decodedConfig = try VMConfig(fromJSON: encodedConfigData)
+    let decodedLinux = try XCTUnwrap(decodedConfig.platform as? Linux)
+    let decodedMachineIdentifier = try XCTUnwrap(decodedLinux.machineIdentifier)
+
+    XCTAssertEqual(
+      decodedMachineIdentifier.dataRepresentation,
+      originalIdentifier.dataRepresentation,
+      "decoded machine identifier should match original identifier"
+    )
+
+    let platformConfiguration = try decodedLinux.platform(
+      nvramURL: URL(fileURLWithPath: "/dev/null"),
+      needsNestedVirtualization: false
+    )
+    let decodedPlatformConfiguration = try XCTUnwrap(
+      platformConfiguration as? VZGenericPlatformConfiguration
+    )
+
+    XCTAssertEqual(
+      decodedPlatformConfiguration.machineIdentifier.dataRepresentation,
+      originalIdentifier.dataRepresentation,
+      "platform configuration should reuse decoded machine identifier"
+    )
+  }
+
+  func testLegacyLinuxConfigWithoutMachineIdentifier() throws {
+    let originalIdentifier = VZGenericMachineIdentifier()
+    let originalConfig = VMConfig(
+      platform: Linux(machineIdentifier: originalIdentifier), cpuCountMin: 2, memorySizeMin: 1024 * 1024 * 1024
+    )
+    let encodedConfigData = try originalConfig.toJSON()
+
+    var configJSONObject = try XCTUnwrap(JSONSerialization.jsonObject(with: encodedConfigData) as? [String: Any])
+    configJSONObject.removeValue(forKey: "machineIdentifier")
+    let legacyConfigData = try JSONSerialization.data(withJSONObject: configJSONObject)
+
+    let decodedConfig = try VMConfig(fromJSON: legacyConfigData)
+    let decodedLinux = try XCTUnwrap(decodedConfig.platform as? Linux)
+
+    XCTAssertNil(decodedLinux.machineIdentifier, "missing machineIdentifier should be decoded as nil")
   }
 }


### PR DESCRIPTION
Fixes #1177

## Summary

Previous investigation in #796 and #1177 implied that restoring suspended Linux VMs wasn't supported by Virtualization.framework. Some testing on current macOS shows that Linux restoration does actually work properly, and that Tart's existing suspend/restore mechanisms were very close to working.

The `Darwin` platform implementation persists the VM's ECID and assigns it to `VZMacPlatformConfiguration.machineIdentifier`. However, the `Linux` platform didn't specify a `machineIdentifier` when constructing its `VZGenericPlatformConfiguration`, which caused a new identifier to be generated each time the platform was instantiated.

Unfortunately, Virtualization.framework returns a very opaque error if saved machine state is restored with a mismatched identifier:

```text
Error Domain=VZErrorDomain Code=12 "The virtual machine failed to restore with error “invalid argument”."
```

This PR generates and persists a `VZGenericMachineIdentifier` in new Linux VM config files, then reuses it whenever the platform is constructed. The goal is to get the Linux behavior as close as possible to the existing Darwin behavior (with the exception of handling legacy config files with no machineIdentifier). Future work could probably align these more closely, but I'd like to keep this PR as minimal as I can.

Now, existing Linux configs without a `machineIdentifier` are loadable for normal use but can't be suspended. When cloning a stopped legacy Linux VM, the missing `machineIdentifier` is initialized in the new clone. Existing identifiers are preserved, matching Tart's current behavior for Darwin ECIDs, and suspended clones keep their original identity and saved state.

The `Linux` platform now conforms to PlatformSuspendable. Suspendable Linux VMs retain USB keyboard support but omit VZUSBScreenCoordinatePointingDeviceConfiguration, which passes validateSaveRestoreSupport() but causes restoration to fail.

## Testing

- The full Swift test suite passes.
- Two unit tests cover identifier serialization and platform reconstruction, plus legacy configuration compatibility.
- A current Ubuntu OCI image without an identifier was cloned and verified to receive one before its first run.
- The resulting Ubuntu VM was started, suspended, and restored while streaming an in-memory counter over UDP to the host:

```text
boot=d055e850-7951-4744-8790-380df1fa628c pid=1031 count=109
boot=d055e850-7951-4744-8790-380df1fa628c pid=1031 count=110
boot=d055e850-7951-4744-8790-380df1fa628c pid=1031 count=111
# VM suspended
# VM restored
boot=d055e850-7951-4744-8790-380df1fa628c pid=1031 count=112
boot=d055e850-7951-4744-8790-380df1fa628c pid=1031 count=113
```

The matching boot ID and PID with a continuously incrementing counter confirm that saved machine state was restored rather than cold-booted.