### PR TITLE
Fix OCI prune cleanup of broken tag symlinks

### DIFF
--- a/Sources/tart/Commands/Prune.swift
+++ b/Sources/tart/Commands/Prune.swift
@@ -75,9 +75,13 @@ struct Prune: AsyncParsableCommand {
   }
 
   static func pruneOlderThan(prunableStorages: [PrunableStorage], olderThanDate: Date) throws {
-    let prunables: [Prunable] = try prunableStorages.flatMap { try $0.prunables() }
-
-    try prunables.filter { try $0.accessDate() <= olderThanDate }.forEach { try $0.delete() }
+    while let prunable = try prunableStorages
+      .flatMap({ try $0.prunables() })
+      .first(where: { try $0.accessDate() <= olderThanDate }) {
+      // Deletion may remove derived prunables (for example shared content),
+      // so never continue from a stale snapshot.
+      try prunable.delete()
+    }
   }
 
   static func pruneSpaceBudget(prunableStorages: [PrunableStorage], spaceBudgetBytes: UInt64) throws {

--- a/Sources/tart/Commands/Prune.swift
+++ b/Sources/tart/Commands/Prune.swift
@@ -72,12 +72,6 @@ struct Prune: AsyncParsableCommand {
     if let spaceBudget = spaceBudget {
       try Prune.pruneSpaceBudget(prunableStorages: prunableStorages, spaceBudgetBytes: UInt64(spaceBudget) * 1024 * 1024 * 1024)
     }
-
-    // Pruning digest-addressed OCI images can leave their tag symlinks broken.
-    // Run garbage collection after deletion so it can remove those links.
-    if entries == "caches" && (olderThan != nil || spaceBudget != nil) {
-      try VMStorageOCI().gc()
-    }
   }
 
   static func pruneOlderThan(prunableStorages: [PrunableStorage], olderThanDate: Date) throws {

--- a/Sources/tart/Commands/Prune.swift
+++ b/Sources/tart/Commands/Prune.swift
@@ -72,6 +72,12 @@ struct Prune: AsyncParsableCommand {
     if let spaceBudget = spaceBudget {
       try Prune.pruneSpaceBudget(prunableStorages: prunableStorages, spaceBudgetBytes: UInt64(spaceBudget) * 1024 * 1024 * 1024)
     }
+
+    // Pruning digest-addressed OCI images can leave their tag symlinks broken.
+    // Run garbage collection after deletion so it can remove those links.
+    if entries == "caches" && (olderThan != nil || spaceBudget != nil) {
+      try VMStorageOCI().gc()
+    }
   }
 
   static func pruneOlderThan(prunableStorages: [PrunableStorage], olderThanDate: Date) throws {

--- a/Sources/tart/Commands/Prune.swift
+++ b/Sources/tart/Commands/Prune.swift
@@ -75,12 +75,18 @@ struct Prune: AsyncParsableCommand {
   }
 
   static func pruneOlderThan(prunableStorages: [PrunableStorage], olderThanDate: Date) throws {
-    while let prunable = try prunableStorages
-      .flatMap({ try $0.prunables() })
-      .first(where: { try $0.accessDate() <= olderThanDate }) {
-      // Deletion may remove derived prunables (for example shared content),
-      // so never continue from a stale snapshot.
-      try prunable.delete()
+    let prunables = try prunableStorages.flatMap { try $0.prunables() }
+
+    for prunable in prunables {
+      // Deleting a cached image may also collect its now-unreferenced content,
+      // so tolerate derived entries that disappeared from the snapshot.
+      guard FileManager.default.fileExists(atPath: prunable.url.path) else {
+        continue
+      }
+
+      if try prunable.accessDate() <= olderThanDate {
+        try prunable.delete()
+      }
     }
   }
 

--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -294,7 +294,15 @@ class VMStorageOCI: PrunableStorage {
       return
     }
 
-    let standardizedTargetPath = targetURL.absoluteURL.standardizedFileURL.path
+    let normalizedPath: (URL) -> String = { url in
+      var path = url.absoluteURL.standardizedFileURL.path
+      while path.count > 1 && path.hasSuffix("/") {
+        path.removeLast()
+      }
+      return path
+    }
+
+    let standardizedTargetPath = normalizedPath(targetURL)
     for case let foundURL as URL in enumerator {
       guard try foundURL.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink == true else {
         continue
@@ -304,8 +312,8 @@ class VMStorageOCI: PrunableStorage {
       let destinationURL = URL(
         fileURLWithPath: destination,
         relativeTo: foundURL.deletingLastPathComponent()
-      ).standardizedFileURL
-      if destinationURL.path == standardizedTargetPath {
+      )
+      if normalizedPath(destinationURL) == standardizedTargetPath {
         try FileManager.default.removeItem(at: foundURL)
       }
     }

--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -291,15 +291,19 @@ class VMStorageOCI: PrunableStorage {
     return path
   }
 
+  private func canonicalPath(_ url: URL) -> String {
+    normalizedPath(url.resolvingSymlinksInPath())
+  }
+
   /// Find tag links that point at a cached image before its directory is removed.
   fileprivate func tagSymlinks(pointingTo targetURL: URL) throws -> [URL] {
-    let standardizedTargetPath = normalizedPath(targetURL)
+    let canonicalTargetPath = canonicalPath(targetURL)
     return try list().compactMap { (_, vmDir, isSymlink) in
       guard isSymlink else {
         return nil
       }
 
-      guard normalizedPath(vmDir.baseURL.resolvingSymlinksInPath()) == standardizedTargetPath else {
+      guard canonicalPath(vmDir.baseURL) == canonicalTargetPath else {
         return nil
       }
 
@@ -309,7 +313,7 @@ class VMStorageOCI: PrunableStorage {
 
   /// Remove only the links previously identified for a deleted cached image.
   fileprivate func removeTagSymlinks(at urls: [URL], pointingTo targetURL: URL) throws {
-    let standardizedTargetPath = normalizedPath(targetURL)
+    let canonicalTargetPath = canonicalPath(targetURL)
     for foundURL in urls {
       guard let destination = try? FileManager.default.destinationOfSymbolicLink(atPath: foundURL.path) else {
         continue
@@ -319,7 +323,7 @@ class VMStorageOCI: PrunableStorage {
         fileURLWithPath: destination,
         relativeTo: foundURL.deletingLastPathComponent()
       ).absoluteURL.standardizedFileURL
-      if normalizedPath(destinationURL) == standardizedTargetPath {
+      if canonicalPath(destinationURL) == canonicalTargetPath {
         try FileManager.default.removeItem(at: foundURL)
       }
     }

--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -294,7 +294,7 @@ class VMStorageOCI: PrunableStorage {
       return
     }
 
-    let standardizedTargetURL = targetURL.standardizedFileURL
+    let standardizedTargetPath = targetURL.standardizedFileURL.path
     for case let foundURL as URL in enumerator {
       guard try foundURL.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink == true else {
         continue
@@ -305,7 +305,7 @@ class VMStorageOCI: PrunableStorage {
         fileURLWithPath: destination,
         relativeTo: foundURL.deletingLastPathComponent()
       ).standardizedFileURL
-      if destinationURL == standardizedTargetURL {
+      if destinationURL.path == standardizedTargetPath {
         try FileManager.default.removeItem(at: foundURL)
       }
     }

--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -271,35 +271,6 @@ class VMStorageOCI: PrunableStorage {
     try VMDirectory(baseURL: url).removeFromDisk()
   }
 
-  /// Remove tag links which now point to a cached image record that was deleted.
-  fileprivate func removeTagLinks(to deletedRecordURL: URL) throws {
-    let contentStore = try ContentStore()
-    try contentStore.withPruneLock {
-      guard let enumerator = FileManager.default.enumerator(at: baseURL,
-                                                            includingPropertiesForKeys: [.isSymbolicLinkKey]) else {
-        return
-      }
-
-      let deletedPath = deletedRecordURL.standardizedFileURL.path
-      for case let foundURL as URL in enumerator {
-        guard try foundURL.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink! else {
-          continue
-        }
-
-        let destination = try FileManager.default.destinationOfSymbolicLink(atPath: foundURL.path)
-        let destinationURL: URL
-        if destination.hasPrefix("/") {
-          destinationURL = URL(fileURLWithPath: destination)
-        } else {
-          destinationURL = URL(fileURLWithPath: destination, relativeTo: foundURL.deletingLastPathComponent())
-        }
-        if destinationURL.standardizedFileURL.path == deletedPath {
-          try FileManager.default.removeItem(at: foundURL)
-        }
-      }
-    }
-  }
-
   /// Remove immutable files whose final published or in-progress reference
   /// has disappeared, without collecting unrelated cached images.
   fileprivate func gcContent() throws {
@@ -859,9 +830,10 @@ private struct CachedImagePrunable: Prunable {
 
   func delete() throws {
     try vmDir.delete()
-    let storage = try VMStorageOCI()
-    try storage.removeTagLinks(to: vmDir.url)
-    try storage.gcContent()
+    // Deleting a record can leave tag symlinks broken and make attributed
+    // content unreferenced. Run the complete GC now so one prune invocation
+    // reclaims both kinds of garbage.
+    try VMStorageOCI().gc()
   }
 
   func accessDate() throws -> Date {

--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -283,6 +283,34 @@ class VMStorageOCI: PrunableStorage {
     }
   }
 
+  /// Remove tag links that point at a cached image which has just been deleted.
+  /// Keep this targeted so deleting one prune candidate cannot collect other
+  /// unreferenced cached images that a caller may still need to consider.
+  fileprivate func removeTagSymlinks(pointingTo targetURL: URL) throws {
+    guard let enumerator = FileManager.default.enumerator(
+      at: baseURL,
+      includingPropertiesForKeys: [.isSymbolicLinkKey]
+    ) else {
+      return
+    }
+
+    let standardizedTargetURL = targetURL.standardizedFileURL
+    for case let foundURL as URL in enumerator {
+      guard try foundURL.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink == true else {
+        continue
+      }
+
+      let destination = try FileManager.default.destinationOfSymbolicLink(atPath: foundURL.path)
+      let destinationURL = URL(
+        fileURLWithPath: destination,
+        relativeTo: foundURL.deletingLastPathComponent()
+      ).standardizedFileURL
+      if destinationURL == standardizedTargetURL {
+        try FileManager.default.removeItem(at: foundURL)
+      }
+    }
+  }
+
   func list() throws -> [(String, VMDirectory, Bool)] {
     var result: [(String, VMDirectory, Bool)] = Array()
 
@@ -830,10 +858,9 @@ private struct CachedImagePrunable: Prunable {
 
   func delete() throws {
     try vmDir.delete()
-    // Deleting a record can leave tag symlinks broken and make attributed
-    // content unreferenced. Run the complete GC now so one prune invocation
-    // reclaims both kinds of garbage.
-    try VMStorageOCI().gc()
+    let storage = try VMStorageOCI()
+    try storage.removeTagSymlinks(pointingTo: vmDir.url)
+    try storage.gcContent()
   }
 
   func accessDate() throws -> Date {

--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -287,7 +287,12 @@ class VMStorageOCI: PrunableStorage {
         }
 
         let destination = try FileManager.default.destinationOfSymbolicLink(atPath: foundURL.path)
-        let destinationURL = URL(fileURLWithPath: destination, relativeTo: foundURL.deletingLastPathComponent())
+        let destinationURL: URL
+        if destination.hasPrefix("/") {
+          destinationURL = URL(fileURLWithPath: destination)
+        } else {
+          destinationURL = URL(fileURLWithPath: destination, relativeTo: foundURL.deletingLastPathComponent())
+        }
         if destinationURL.standardizedFileURL.path == deletedPath {
           try FileManager.default.removeItem(at: foundURL)
         }

--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -271,6 +271,30 @@ class VMStorageOCI: PrunableStorage {
     try VMDirectory(baseURL: url).removeFromDisk()
   }
 
+  /// Remove tag links which now point to a cached image record that was deleted.
+  fileprivate func removeTagLinks(to deletedRecordURL: URL) throws {
+    let contentStore = try ContentStore()
+    try contentStore.withPruneLock {
+      guard let enumerator = FileManager.default.enumerator(at: baseURL,
+                                                            includingPropertiesForKeys: [.isSymbolicLinkKey]) else {
+        return
+      }
+
+      let deletedPath = deletedRecordURL.standardizedFileURL.path
+      for case let foundURL as URL in enumerator {
+        guard try foundURL.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink! else {
+          continue
+        }
+
+        let destination = try FileManager.default.destinationOfSymbolicLink(atPath: foundURL.path)
+        let destinationURL = URL(fileURLWithPath: destination, relativeTo: foundURL.deletingLastPathComponent())
+        if destinationURL.standardizedFileURL.path == deletedPath {
+          try FileManager.default.removeItem(at: foundURL)
+        }
+      }
+    }
+  }
+
   /// Remove immutable files whose final published or in-progress reference
   /// has disappeared, without collecting unrelated cached images.
   fileprivate func gcContent() throws {
@@ -830,10 +854,9 @@ private struct CachedImagePrunable: Prunable {
 
   func delete() throws {
     try vmDir.delete()
-    // Deleting a record can leave tag symlinks broken and make attributed
-    // content unreferenced. Run the complete GC now so one prune invocation
-    // reclaims both kinds of garbage.
-    try VMStorageOCI().gc()
+    let storage = try VMStorageOCI()
+    try storage.removeTagLinks(to: vmDir.url)
+    try storage.gcContent()
   }
 
   func accessDate() throws -> Date {

--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -830,9 +830,10 @@ private struct CachedImagePrunable: Prunable {
 
   func delete() throws {
     try vmDir.delete()
-    // Deleting a record can make attributed content unreferenced. Run GC now
-    // so one prune invocation reclaims those bytes.
-    try VMStorageOCI().gcContent()
+    // Deleting a record can leave tag symlinks broken and make attributed
+    // content unreferenced. Run the complete GC now so one prune invocation
+    // reclaims both kinds of garbage.
+    try VMStorageOCI().gc()
   }
 
   func accessDate() throws -> Date {

--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -283,27 +283,46 @@ class VMStorageOCI: PrunableStorage {
     }
   }
 
-  /// Remove tag links that point at a cached image which has just been deleted.
-  /// Keep this targeted so deleting one prune candidate cannot collect other
-  /// unreferenced cached images that a caller may still need to consider.
-  fileprivate func removeTagSymlinks(pointingTo targetURL: URL) throws {
+  private func normalizedPath(_ url: URL) -> String {
+    var path = url.absoluteURL.standardizedFileURL.path
+    while path.count > 1 && path.hasSuffix("/") {
+      path.removeLast()
+    }
+    return path
+  }
+
+  /// Find tag links that point at a cached image before its directory is removed.
+  fileprivate func tagSymlinks(pointingTo targetURL: URL) throws -> [URL] {
     guard let enumerator = FileManager.default.enumerator(
       at: baseURL,
       includingPropertiesForKeys: [.isSymbolicLinkKey]
     ) else {
-      return
-    }
-
-    let normalizedPath: (URL) -> String = { url in
-      var path = url.absoluteURL.standardizedFileURL.path
-      while path.count > 1 && path.hasSuffix("/") {
-        path.removeLast()
-      }
-      return path
+      return []
     }
 
     let standardizedTargetPath = normalizedPath(targetURL)
+    var result = [URL]()
     for case let foundURL as URL in enumerator {
+      guard try foundURL.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink == true else {
+        continue
+      }
+
+      let destination = try FileManager.default.destinationOfSymbolicLink(atPath: foundURL.path)
+      let destinationURL = URL(
+        fileURLWithPath: destination,
+        relativeTo: foundURL.deletingLastPathComponent()
+      ).absoluteURL.standardizedFileURL
+      if normalizedPath(destinationURL) == standardizedTargetPath {
+        result.append(foundURL)
+      }
+    }
+    return result
+  }
+
+  /// Remove only the links previously identified for a deleted cached image.
+  fileprivate func removeTagSymlinks(at urls: [URL], pointingTo targetURL: URL) throws {
+    let standardizedTargetPath = normalizedPath(targetURL)
+    for foundURL in urls {
       guard try foundURL.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink == true else {
         continue
       }
@@ -865,9 +884,10 @@ private struct CachedImagePrunable: Prunable {
   }
 
   func delete() throws {
-    try vmDir.delete()
     let storage = try VMStorageOCI()
-    try storage.removeTagSymlinks(pointingTo: vmDir.url)
+    let tagSymlinks = try storage.tagSymlinks(pointingTo: vmDir.url)
+    try vmDir.delete()
+    try storage.removeTagSymlinks(at: tagSymlinks, pointingTo: vmDir.url)
     try storage.gcContent()
   }
 

--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -293,30 +293,18 @@ class VMStorageOCI: PrunableStorage {
 
   /// Find tag links that point at a cached image before its directory is removed.
   fileprivate func tagSymlinks(pointingTo targetURL: URL) throws -> [URL] {
-    guard let enumerator = FileManager.default.enumerator(
-      at: baseURL,
-      includingPropertiesForKeys: [.isSymbolicLinkKey]
-    ) else {
-      return []
-    }
-
     let standardizedTargetPath = normalizedPath(targetURL)
-    var result = [URL]()
-    for case let foundURL as URL in enumerator {
-      guard try foundURL.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink == true else {
-        continue
+    return try list().compactMap { (_, vmDir, isSymlink) in
+      guard isSymlink else {
+        return nil
       }
 
-      let destination = try FileManager.default.destinationOfSymbolicLink(atPath: foundURL.path)
-      let destinationURL = URL(
-        fileURLWithPath: destination,
-        relativeTo: foundURL.deletingLastPathComponent()
-      ).absoluteURL.standardizedFileURL
-      if normalizedPath(destinationURL) == standardizedTargetPath {
-        result.append(foundURL)
+      guard normalizedPath(vmDir.baseURL.resolvingSymlinksInPath()) == standardizedTargetPath else {
+        return nil
       }
+
+      return vmDir.baseURL
     }
-    return result
   }
 
   /// Remove only the links previously identified for a deleted cached image.

--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -312,7 +312,7 @@ class VMStorageOCI: PrunableStorage {
       let destinationURL = URL(
         fileURLWithPath: destination,
         relativeTo: foundURL.deletingLastPathComponent()
-      )
+      ).absoluteURL.standardizedFileURL
       if normalizedPath(destinationURL) == standardizedTargetPath {
         try FileManager.default.removeItem(at: foundURL)
       }

--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -323,11 +323,10 @@ class VMStorageOCI: PrunableStorage {
   fileprivate func removeTagSymlinks(at urls: [URL], pointingTo targetURL: URL) throws {
     let standardizedTargetPath = normalizedPath(targetURL)
     for foundURL in urls {
-      guard try foundURL.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink == true else {
+      guard let destination = try? FileManager.default.destinationOfSymbolicLink(atPath: foundURL.path) else {
         continue
       }
 
-      let destination = try FileManager.default.destinationOfSymbolicLink(atPath: foundURL.path)
       let destinationURL = URL(
         fileURLWithPath: destination,
         relativeTo: foundURL.deletingLastPathComponent()

--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -294,7 +294,7 @@ class VMStorageOCI: PrunableStorage {
       return
     }
 
-    let standardizedTargetPath = targetURL.standardizedFileURL.path
+    let standardizedTargetPath = targetURL.absoluteURL.standardizedFileURL.path
     for case let foundURL as URL in enumerator {
       guard try foundURL.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink == true else {
         continue

--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -283,8 +283,16 @@ class VMStorageOCI: PrunableStorage {
     }
   }
 
+  private func absoluteURL(_ url: URL) -> URL {
+    guard !url.path.hasPrefix("/") else {
+      return url
+    }
+
+    return URL(fileURLWithPath: url.path, relativeTo: baseURL).absoluteURL
+  }
+
   private func normalizedPath(_ url: URL) -> String {
-    var path = url.absoluteURL.standardizedFileURL.path
+    var path = absoluteURL(url).standardizedFileURL.path
     while path.count > 1 && path.hasSuffix("/") {
       path.removeLast()
     }
@@ -292,7 +300,7 @@ class VMStorageOCI: PrunableStorage {
   }
 
   private func canonicalPath(_ url: URL) -> String {
-    normalizedPath(url.resolvingSymlinksInPath())
+    normalizedPath(absoluteURL(url).resolvingSymlinksInPath())
   }
 
   /// Find tag links that point at a cached image before its directory is removed.
@@ -307,7 +315,7 @@ class VMStorageOCI: PrunableStorage {
         return nil
       }
 
-      return URL(fileURLWithPath: vmDir.baseURL.path, relativeTo: baseURL).standardizedFileURL
+      return absoluteURL(vmDir.baseURL).standardizedFileURL
     }
   }
 

--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -307,7 +307,7 @@ class VMStorageOCI: PrunableStorage {
         return nil
       }
 
-      return vmDir.baseURL
+      return URL(fileURLWithPath: vmDir.baseURL.path, relativeTo: baseURL).standardizedFileURL
     }
   }
 

--- a/Tests/TartTests/VMStorageOCITests.swift
+++ b/Tests/TartTests/VMStorageOCITests.swift
@@ -737,10 +737,12 @@ final class VMStorageOCITests: XCTestCase {
       // Use syntactically valid digests here; the test only exercises record
       // and tag-symlink cleanup, not content installation.
       let deletedManifest = try stackedManifest(
-        baseContentDigest: "sha256:" + String(repeating: "a", count: 64)
+        baseContentDigest: "sha256:" + String(repeating: "a", count: 64),
+        overlayContentDigest: "sha256:" + String(repeating: "e", count: 64)
       )
       let retainedManifest = try stackedManifest(
-        baseContentDigest: "sha256:" + String(repeating: "b", count: 64)
+        baseContentDigest: "sha256:" + String(repeating: "b", count: 64),
+        overlayContentDigest: "sha256:" + String(repeating: "f", count: 64)
       )
       let deletedName = try digestName(for: deletedManifest)
       let deletedRecord = try createRecord(for: deletedManifest, in: storage)
@@ -748,6 +750,9 @@ final class VMStorageOCITests: XCTestCase {
       let tagURL = storage.baseURL.appendingRemoteName(tagName)
       try storage.link(from: tagName, to: deletedName)
       let retainedRecord = try createRecord(for: retainedManifest, in: storage)
+      let retainedTagName = RemoteName(host: "example.com", namespace: "org/image", reference: Reference(tag: "retained"))
+      let retainedTagURL = storage.baseURL.appendingRemoteName(retainedTagName)
+      try storage.link(from: retainedTagName, to: try digestName(for: retainedManifest))
       try deletedRecord.url.updateAccessDate(Date(timeIntervalSince1970: 1))
 
       try Prune.pruneOlderThan(
@@ -758,6 +763,40 @@ final class VMStorageOCITests: XCTestCase {
       XCTAssertFalse(FileManager.default.fileExists(atPath: deletedRecord.url.path))
       XCTAssertThrowsError(try FileManager.default.destinationOfSymbolicLink(atPath: tagURL.path))
       XCTAssertTrue(FileManager.default.fileExists(atPath: retainedRecord.url.path))
+      XCTAssertTrue(FileManager.default.fileExists(atPath: retainedTagURL.path))
+    }
+  }
+
+  func testSpaceBudgetPruningCachedImageRemovesOnlyItsTagSymlink() throws {
+    try withTemporaryTartHome {
+      let storage = try VMStorageOCI()
+      let deletedManifest = try stackedManifest(
+        baseContentDigest: "sha256:" + String(repeating: "c", count: 64),
+        overlayContentDigest: "sha256:" + String(repeating: "0", count: 64)
+      )
+      let retainedManifest = try stackedManifest(
+        baseContentDigest: "sha256:" + String(repeating: "d", count: 64),
+        overlayContentDigest: "sha256:" + String(repeating: "1", count: 64)
+      )
+      let deletedName = try digestName(for: deletedManifest)
+      let deletedRecord = try createRecord(for: deletedManifest, in: storage)
+      let tagName = RemoteName(host: "example.com", namespace: "org/image", reference: Reference(tag: "deleted"))
+      let tagURL = storage.baseURL.appendingRemoteName(tagName)
+      try storage.link(from: tagName, to: deletedName)
+      let retainedRecord = try createRecord(for: retainedManifest, in: storage)
+      let retainedTagName = RemoteName(host: "example.com", namespace: "org/image", reference: Reference(tag: "retained"))
+      let retainedTagURL = storage.baseURL.appendingRemoteName(retainedTagName)
+      try storage.link(from: retainedTagName, to: try digestName(for: retainedManifest))
+      try deletedRecord.url.updateAccessDate(Date(timeIntervalSince1970: 1))
+      try retainedRecord.url.updateAccessDate(Date(timeIntervalSince1970: 2))
+      let retainedSize = UInt64(try retainedRecord.url.allocatedSizeBytes())
+
+      try Prune.pruneSpaceBudget(prunableStorages: [storage], spaceBudgetBytes: retainedSize)
+
+      XCTAssertFalse(FileManager.default.fileExists(atPath: deletedRecord.url.path))
+      XCTAssertThrowsError(try FileManager.default.destinationOfSymbolicLink(atPath: tagURL.path))
+      XCTAssertTrue(FileManager.default.fileExists(atPath: retainedRecord.url.path))
+      XCTAssertTrue(FileManager.default.fileExists(atPath: retainedTagURL.path))
     }
   }
 

--- a/Tests/TartTests/VMStorageOCITests.swift
+++ b/Tests/TartTests/VMStorageOCITests.swift
@@ -767,7 +767,7 @@ final class VMStorageOCITests: XCTestCase {
       )
 
       XCTAssertFalse(FileManager.default.fileExists(atPath: deletedRecord.url.path))
-      XCTAssertThrowsError(try FileManager.default.destinationOfSymbolicLink(atPath: tagURL.path))
+      XCTAssertFalse(FileManager.default.fileExists(atPath: tagURL.path))
       XCTAssertTrue(FileManager.default.fileExists(atPath: retainedRecord.url.path))
       XCTAssertTrue(FileManager.default.fileExists(atPath: retainedTagURL.path))
     }
@@ -800,7 +800,7 @@ final class VMStorageOCITests: XCTestCase {
       try Prune.pruneSpaceBudget(prunableStorages: [storage], spaceBudgetBytes: retainedSize)
 
       XCTAssertFalse(FileManager.default.fileExists(atPath: deletedRecord.url.path))
-      XCTAssertThrowsError(try FileManager.default.destinationOfSymbolicLink(atPath: tagURL.path))
+      XCTAssertFalse(FileManager.default.fileExists(atPath: tagURL.path))
       XCTAssertTrue(FileManager.default.fileExists(atPath: retainedRecord.url.path))
       XCTAssertTrue(FileManager.default.fileExists(atPath: retainedTagURL.path))
     }

--- a/Tests/TartTests/VMStorageOCITests.swift
+++ b/Tests/TartTests/VMStorageOCITests.swift
@@ -733,8 +733,15 @@ final class VMStorageOCITests: XCTestCase {
   func testPruningCachedImageRemovesOnlyItsTagSymlink() throws {
     try withTemporaryTartHome {
       let storage = try VMStorageOCI()
-      let deletedManifest = try stackedManifest(baseContentDigest: "sha256:deleted")
-      let retainedManifest = try stackedManifest(baseContentDigest: "sha256:retained")
+      // Content digests are validated when manifests are scanned for pruning.
+      // Use syntactically valid digests here; the test only exercises record
+      // and tag-symlink cleanup, not content installation.
+      let deletedManifest = try stackedManifest(
+        baseContentDigest: "sha256:" + String(repeating: "a", count: 64)
+      )
+      let retainedManifest = try stackedManifest(
+        baseContentDigest: "sha256:" + String(repeating: "b", count: 64)
+      )
       let deletedName = try digestName(for: deletedManifest)
       let deletedRecord = try createRecord(for: deletedManifest, in: storage)
       let tagName = RemoteName(host: "example.com", namespace: "org/image", reference: Reference(tag: "deleted"))

--- a/Tests/TartTests/VMStorageOCITests.swift
+++ b/Tests/TartTests/VMStorageOCITests.swift
@@ -761,6 +761,11 @@ final class VMStorageOCITests: XCTestCase {
       try storage.link(from: retainedTagName, to: try digestName(for: retainedManifest))
       try deletedRecord.url.updateAccessDate(Date(timeIntervalSince1970: 1))
 
+      let prunableURL = try storage.prunables().first { $0.url.lastPathComponent == deletedRecord.url.lastPathComponent }!.url
+      let destination = try FileManager.default.destinationOfSymbolicLink(atPath: tagURL.path)
+      let destinationURL = URL(fileURLWithPath: destination, relativeTo: tagURL.deletingLastPathComponent())
+      print("PRUNE DEBUG base=\(storage.baseURL.absoluteString) record=\(deletedRecord.url.absoluteString) candidate=\(prunableURL.absoluteString) targetPath=\(prunableURL.absoluteURL.standardizedFileURL.path) destination=\(destination) destinationURL=\(destinationURL.absoluteString) destinationPath=\(destinationURL.absoluteURL.standardizedFileURL.path) destinationBase=\(destinationURL.baseURL?.absoluteString ?? \"nil\")")
+
       try Prune.pruneOlderThan(
         prunableStorages: [storage],
         olderThanDate: Date(timeIntervalSince1970: 2)

--- a/Tests/TartTests/VMStorageOCITests.swift
+++ b/Tests/TartTests/VMStorageOCITests.swift
@@ -795,7 +795,7 @@ final class VMStorageOCITests: XCTestCase {
       try storage.link(from: retainedTagName, to: try digestName(for: retainedManifest))
       try deletedRecord.url.updateAccessDate(Date(timeIntervalSince1970: 1))
       try retainedRecord.url.updateAccessDate(Date(timeIntervalSince1970: 2))
-      let retainedSize = UInt64(try retainedRecord.url.allocatedSizeBytes())
+      let retainedSize = UInt64(try retainedRecord.allocatedSizeBytes())
 
       try Prune.pruneSpaceBudget(prunableStorages: [storage], spaceBudgetBytes: retainedSize)
 

--- a/Tests/TartTests/VMStorageOCITests.swift
+++ b/Tests/TartTests/VMStorageOCITests.swift
@@ -730,6 +730,30 @@ final class VMStorageOCITests: XCTestCase {
     }
   }
 
+  func testPruningCachedImageRemovesOnlyItsTagSymlink() throws {
+    try withTemporaryTartHome {
+      let storage = try VMStorageOCI()
+      let deletedManifest = try stackedManifest(baseContentDigest: "sha256:deleted")
+      let retainedManifest = try stackedManifest(baseContentDigest: "sha256:retained")
+      let deletedName = try digestName(for: deletedManifest)
+      let deletedRecord = try createRecord(for: deletedManifest, in: storage)
+      let tagName = RemoteName(host: "example.com", namespace: "org/image", reference: Reference(tag: "deleted"))
+      let tagURL = storage.baseURL.appendingRemoteName(tagName)
+      try storage.link(from: tagName, to: deletedName)
+      let retainedRecord = try createRecord(for: retainedManifest, in: storage)
+      try deletedRecord.url.updateAccessDate(Date(timeIntervalSince1970: 1))
+
+      try Prune.pruneOlderThan(
+        prunableStorages: [storage],
+        olderThanDate: Date(timeIntervalSince1970: 2)
+      )
+
+      XCTAssertFalse(FileManager.default.fileExists(atPath: deletedRecord.url.path))
+      XCTAssertThrowsError(try FileManager.default.destinationOfSymbolicLink(atPath: tagURL.path))
+      XCTAssertTrue(FileManager.default.fileExists(atPath: retainedRecord.url.path))
+    }
+  }
+
   #if canImport(DiskImageKit)
     @available(macOS 27.0, *)
     func testPopulateStackedPushedImageCachesImmutableTopOverlay() throws {

--- a/Tests/TartTests/VMStorageOCITests.swift
+++ b/Tests/TartTests/VMStorageOCITests.swift
@@ -767,7 +767,7 @@ final class VMStorageOCITests: XCTestCase {
       )
 
       XCTAssertFalse(FileManager.default.fileExists(atPath: deletedRecord.url.path))
-      XCTAssertFalse(FileManager.default.fileExists(atPath: tagURL.path))
+      XCTAssertFalse((try? tagURL.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink) ?? false)
       XCTAssertTrue(FileManager.default.fileExists(atPath: retainedRecord.url.path))
       XCTAssertTrue(FileManager.default.fileExists(atPath: retainedTagURL.path))
     }
@@ -800,7 +800,7 @@ final class VMStorageOCITests: XCTestCase {
       try Prune.pruneSpaceBudget(prunableStorages: [storage], spaceBudgetBytes: retainedSize)
 
       XCTAssertFalse(FileManager.default.fileExists(atPath: deletedRecord.url.path))
-      XCTAssertFalse(FileManager.default.fileExists(atPath: tagURL.path))
+      XCTAssertFalse((try? tagURL.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink) ?? false)
       XCTAssertTrue(FileManager.default.fileExists(atPath: retainedRecord.url.path))
       XCTAssertTrue(FileManager.default.fileExists(atPath: retainedTagURL.path))
     }

--- a/Tests/TartTests/VMStorageOCITests.swift
+++ b/Tests/TartTests/VMStorageOCITests.swift
@@ -761,11 +761,6 @@ final class VMStorageOCITests: XCTestCase {
       try storage.link(from: retainedTagName, to: try digestName(for: retainedManifest))
       try deletedRecord.url.updateAccessDate(Date(timeIntervalSince1970: 1))
 
-      let prunableURL = try storage.prunables().first { $0.url.lastPathComponent == deletedRecord.url.lastPathComponent }!.url
-      let destination = try FileManager.default.destinationOfSymbolicLink(atPath: tagURL.path)
-      let destinationURL = URL(fileURLWithPath: destination, relativeTo: tagURL.deletingLastPathComponent())
-      print("PRUNE DEBUG base=\(storage.baseURL.absoluteString) record=\(deletedRecord.url.absoluteString) candidate=\(prunableURL.absoluteString) targetPath=\(prunableURL.absoluteURL.standardizedFileURL.path) destination=\(destination) destinationURL=\(destinationURL.absoluteString) destinationPath=\(destinationURL.absoluteURL.standardizedFileURL.path) destinationBase=\(destinationURL.baseURL?.absoluteString ?? \"nil\")")
-
       try Prune.pruneOlderThan(
         prunableStorages: [storage],
         olderThanDate: Date(timeIntervalSince1970: 2)

--- a/Tests/TartTests/VMStorageOCITests.swift
+++ b/Tests/TartTests/VMStorageOCITests.swift
@@ -348,8 +348,14 @@ final class VMStorageOCITests: XCTestCase {
   func testTagReplacementWaitsForPruneLock() throws {
     try withTemporaryTartHome {
       let storage = try VMStorageOCI()
-      let firstManifest = try stackedManifest(baseContentDigest: "sha256:first")
-      let secondManifest = try stackedManifest(baseContentDigest: "sha256:second")
+      let firstManifest = try stackedManifest(
+        baseContentDigest: "sha256:" + String(repeating: "1", count: 64),
+        overlayContentDigest: "sha256:" + String(repeating: "2", count: 64)
+      )
+      let secondManifest = try stackedManifest(
+        baseContentDigest: "sha256:" + String(repeating: "3", count: 64),
+        overlayContentDigest: "sha256:" + String(repeating: "4", count: 64)
+      )
       let firstName = try digestName(for: firstManifest)
       let secondName = try digestName(for: secondManifest)
       _ = try createRecord(for: firstManifest, in: storage)


### PR DESCRIPTION
## Summary / Problem

`tart prune` can delete a digest-addressed OCI cache record while leaving tag symlinks pointing to the deleted directory. The cache then contains broken links until a separate garbage-collection run.

## Changes

- Remove only tag symlinks that point to the cached image deleted by the prune operation.
- Collect matching symlink paths before deleting the target, then recheck each destination before removing it.
- Normalize filesystem paths before comparing symlink destinations, including directory URLs with trailing separators.
- Reclaim unreferenced immutable content without running full OCI record garbage collection during each deletion.

## Tests

- `git diff --check` — passed
- `swift test --build-system swiftbuild` — not run locally because Swift/Xcode is unavailable on the Windows development host
- macOS CI run `33786425450` passed the build but still failed only in the two tag-cleanup regression tests; the latest fix is in commit `2fadfec`
- CI run `33787175157` for the latest fix is currently blocked by GitHub fork-workflow approval before jobs start

## Compatibility / Known limitations

No CLI or storage-format changes. Healthy tag symlinks and unrelated cached images are preserved. The macOS XCTest suite cannot be confirmed for the latest fix until an upstream repository administrator approves the fork workflow.

## Issue link

Closes #1293
