### PR TITLE
Pin CI and build actions to full commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: xcode-27
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Build
         run: |
           export COMPILATION_CACHE_ENABLE_CACHING=YES
@@ -32,6 +32,6 @@ jobs:
     runs-on: xcode-27
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Build
         run: swift build --build-system swiftbuild --product tart

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: xcode-27
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: integration-tests/go.mod
           cache-dependency-path: integration-tests/go.sum


### PR DESCRIPTION
CI on #1324 fails during job setup because the repository requires actions to use full commit SHAs. `actions/checkout@v6` and `actions/setup-go@v6` are rejected before the build starts.

Pin those actions to the commits currently referenced by their tags. Pin both `actions/checkout@v5` steps in the manual Build workflow for the same reason. Version comments record the corresponding releases.

Validation:
- Verified each new SHA against the action repository's major and release tags through the GitHub API.
- Parsed all three workflow files and confirmed all 11 external action references use 40-character SHAs.
- Compared parsed workflows with the base commit and confirmed only the four intended action references changed.
- `git diff --check` passed.

Failure: https://github.com/openai/tart/actions/runs/33393968353/job/100079098212
