### PR TITLE
VMConfig: Save JSON with sorted keys

### DIFF
--- a/Sources/tart/VMConfig.swift
+++ b/Sources/tart/VMConfig.swift
@@ -99,7 +99,7 @@ struct VMConfig: Codable {
 
   func save(toURL: URL) throws {
     let encoder = JSONEncoder()
-    encoder.outputFormatting = .prettyPrinted
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     try encoder.encode(self).write(to: toURL)
   }
 


### PR DESCRIPTION
This makes it easier to diff `config.json` files, otherwise the keys are in a seemingly random order every time they're saved.